### PR TITLE
Feature/valentine zhuck transient dependency conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4602,9 +4602,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -9564,9 +9564,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/semver": "^7.3.9",
         "axios": "^0.26.0",
-        "express": "^4.17.3"
+        "express": "^4.17.3",
+        "semver": "^7.3.5"
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
@@ -114,6 +116,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
@@ -153,6 +164,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -1286,6 +1306,11 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
+    },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -1372,21 +1397,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.13.0",
@@ -1566,21 +1576,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.13.0",
@@ -3585,6 +3580,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
@@ -4169,21 +4173,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
@@ -4457,7 +4446,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4478,6 +4466,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -5221,12 +5218,17 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -5667,21 +5669,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tsc-watch": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-4.6.0.tgz",
@@ -6035,8 +6022,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -6128,6 +6114,12 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -6160,6 +6152,14 @@
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -7077,6 +7077,11 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
+    "@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
+    },
     "@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -7139,15 +7144,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -7253,15 +7249,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -8775,6 +8762,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -9230,17 +9225,6 @@
         "natural-compare": "^1.4.0",
         "pretty-format": "^27.5.1",
         "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "jest-util": {
@@ -9458,7 +9442,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -9470,6 +9453,14 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "make-error": {
@@ -9991,10 +9982,12 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "send": {
       "version": "0.17.2",
@@ -10318,17 +10311,6 @@
         "make-error": "1.x",
         "semver": "7.x",
         "yargs-parser": "20.x"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "tsc-watch": {
@@ -10590,8 +10572,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "license": "ISC",
   "homepage": "https://github.com/commercehub-pub/dependency-problem#readme",
   "dependencies": {
+    "@types/semver": "^7.3.9",
     "axios": "^0.26.0",
-    "express": "^4.17.3"
+    "express": "^4.17.3",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { getDependency } from './dependency';
+import { getDependency, getDependencyConflicts } from './dependency';
 import express from 'express';
 /**
  * Bootstrap the application framework
@@ -9,6 +9,7 @@ export function createApp() {
   app.use(express.json());
 
   app.get('/dependency/:name/:version', getDependency);
+  app.get('/dependency/:name/:version/conflicts/:compareWith/:compareWithVer', getDependencyConflicts);
 
   return app;
 }

--- a/src/dependency.ts
+++ b/src/dependency.ts
@@ -1,6 +1,8 @@
 import { RequestHandler } from 'express';
 import Axios from 'axios'
-import { NPMPackage } from './types';
+import SemVer from 'semver';
+import { NPMPackage, DependencyInfo, VersionMetadata, VersionMetadataParcer, DependencyConflict } from './types';
+
 
 /**
  * Attempts to retrieve package data from the npm registry and return it
@@ -10,7 +12,7 @@ export const getDependency: RequestHandler = async function (req, res, next) {
 
   try {
     const npmPackage: NPMPackage = (await Axios.get(`https://registry.npmjs.org/${name}/${version}`)).data;
-  
+
     if (!npmPackage) {
       return res.status(200).json(`Package ${name}@${version} not found in registry`);
     }
@@ -20,3 +22,90 @@ export const getDependency: RequestHandler = async function (req, res, next) {
     return next(error);
   }
 };
+
+/**
+ * TBD
+ */
+export const getDependencyConflicts: RequestHandler = async function (req, res, next) {
+  const { name, version, compareWith, compareWithVer } = req.params;
+
+  try {
+    const npmPackage: NPMPackage = (await Axios.get(`https://registry.npmjs.org/${name}/${version}`)).data;
+    const compareWithPackage: NPMPackage = (await Axios.get(`https://registry.npmjs.org/${compareWith}/${compareWithVer}`)).data;
+
+    if (!npmPackage || !compareWithPackage) {
+      return res.status(404).json({
+        msg: 'One or more packages were not found in registry',
+        package: npmPackage,
+        compareWith: compareWithPackage
+      });
+    }
+
+    const depencencyTracker = {};
+    const conflicts: Array<[string, string, string]> = [];
+    
+    await flattenAllDependencies(npmPackage, depencencyTracker, conflicts);
+    await flattenAllDependencies(npmPackage, depencencyTracker, conflicts);
+    
+    return res.status(200).json({
+      dependencies: depencencyTracker,
+      conflics: conflicts
+    });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+const flattenAllDependencies = async function (npmPackage: NPMPackage, dependencyTracker: any, conflicts:Array<[string, string, string]>) {
+  if (!npmPackage || !npmPackage.dependencies)
+    return;
+
+  for (const [depName, depVer] of Object.entries(npmPackage.dependencies)) {
+    // Check if dependency already being tracked
+    let trackingDependency: DependencyInfo = dependencyTracker[depName];
+
+    if (!trackingDependency) {
+      trackingDependency = new DependencyInfo(depName, depVer, [npmPackage.name]);
+      dependencyTracker[depName] = trackingDependency;
+    } else if (!SemVer.intersects(trackingDependency.version, depVer)) {
+      trackingDependency.referredBy.push(npmPackage.name)
+      conflicts.push([depName, trackingDependency.version, depVer]);
+    }
+
+    // Get and load package dependencies in recursion (No Optimization)
+    const depencyPackage: NPMPackage | null = await getNpmPackage(trackingDependency);
+
+    if (!!depencyPackage) {
+      flattenAllDependencies(depencyPackage, dependencyTracker, conflicts)
+    }
+    else {
+      // handle corner case. Means that NPM has no dependency, which is also depencency issue
+      console.warn(`NPM has no depencency ${depName} ver. ${depVer}. Dependency will be skipped`);
+    }
+  }
+
+}
+
+const getNpmPackage = async function ({ name, version }: DependencyInfo): Promise<NPMPackage | null> {
+  if (!name || !version) {
+    console.error(`Missing dependency information (name: ${name}, version: ${version}`);
+    return null;
+  }
+
+  const verMetadata = VersionMetadataParcer.parse(version);
+  
+  if (!verMetadata?.isValid || verMetadata?.isAnyMajorVer) {
+    console.warn(
+      `Invalid or '*' dependency will be skipped (name: ${name}, version: ${version}, isAnyMajorVer: ${verMetadata?.isAnyMajorVer})`);
+    return null;
+  }
+
+  try {
+    const npmPackage: NPMPackage = (await Axios.get(`https://registry.npmjs.org/${name}/${verMetadata.cleanVersion}`)).data;
+    return npmPackage;
+  }
+  catch (error) {
+    console.log(error);
+    return null;
+  }
+} 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+import { raw } from "express";
+import semver from "semver";
+
 /**
  * The result of a package request against `https://registry.npmjs.org`. This is
  * a subset of the returned data, not a full representation, that contains
@@ -34,4 +37,59 @@ export interface NPMPackage {
   dependencies?: {
     [packageName: string]: string;
   };
+}
+
+export interface DependencyConflictResponse{
+  dependencies: any;
+  conflics: Array<[string, string, string]>;
+}
+
+export interface DependencyConflict{
+  dependencyPackageName:string,
+  version:string,
+  conflictWithVersion:string
+}
+
+export class DependencyInfo{
+  name: string;
+  version: string;
+  referredBy: string[];
+    
+  constructor(name: string, version: string, referredBy: string[]){
+    this.name = name;
+    this.version = version;
+    this.referredBy = referredBy;
+  }
+}
+
+export interface VersionMetadata{
+  rawVersion: string;
+  cleanVersion?: string;
+  isValid: boolean;
+  isAnyMajorVer : boolean;
+}
+
+export class VersionMetadataParcer{
+  public static parse(rawVersion: string) : VersionMetadata {  
+    let verMeta: VersionMetadata =  {rawVersion, isValid: true, isAnyMajorVer: false};
+    
+    if (verMeta.rawVersion.trim() === '*'){
+      verMeta.isAnyMajorVer = true;
+      return verMeta;
+    }
+
+    let verToClean = rawVersion;
+
+    // Select latest ver if package ref has multiple alternatives liek '1.0.0 || 2.2.2'
+    const alternatives = verMeta.rawVersion.split('||');
+    if ( alternatives.length > 1 ){
+      verToClean = alternatives[alternatives.length-1].trim();
+    }
+
+    // 
+    //verMeta.cleanVersion = semver.coerce(verToClean, {})?.format();
+    verMeta.cleanVersion = verToClean.replace(/[\^,~,\*,>,=]{0,2}/,'').trim();
+
+    return verMeta;
+  }
 }

--- a/test/dependency.test.ts
+++ b/test/dependency.test.ts
@@ -20,10 +20,34 @@ describe('/package/:name/:version endpoint', () => {
     const packageVersion = '16.13.0';
 
     const res: any = (await axios(
-      `http://localhost:${port}/dependency/${packageName}/${packageVersion}`,
+       `http://localhost:${port}/dependency/${packageName}/${packageVersion}`,
     )).data;
 
     expect(res.name).toEqual(packageName);
     expect(res.version).toEqual(packageVersion);
   });
+
+  it('compare react package with the same version of react package', async () => {
+    const packageName = 'react';
+    const packageVersion = '18.0.0';
+
+    const res: any = (await axios(
+       `http://localhost:${port}/dependency/${packageName}/${packageVersion}/conflicts/${packageName}/${packageVersion}`,
+    )).data;
+
+    expect(res.conflics.length).toEqual(0);
+  });
+
+  it('compare 2 different react packagesversion', async () => {
+    const packageName = 'react';
+    const packageVersion = '18.0.0';
+    const compareWithVer = '16.13.0';
+
+    const res: any = (await axios(
+       `http://localhost:${port}/dependency/${packageName}/${packageVersion}/conflicts/${packageName}/${compareWithVer}`,
+    )).data;
+
+    expect(res.conflics.length).toEqual(0);
+  });
+
 });

--- a/test/dependency.test.ts
+++ b/test/dependency.test.ts
@@ -13,7 +13,7 @@ describe('/package/:name/:version endpoint', () => {
 
   afterAll((done) => {
     server.close(done);
-  });
+  }, 10);
 
   it('responds', async () => {
     const packageName = 'react';
@@ -48,6 +48,24 @@ describe('/package/:name/:version endpoint', () => {
     )).data;
 
     expect(res.conflics.length).toEqual(0);
+  });
+
+  it('compare 2 different react packagesversion', async () => {
+    const packageName = 'react-redux';
+    const packageVersion = '7.2.8';
+    const compareWithVer = '7.2.8';
+
+    const res: any = (await axios(
+       `http://localhost:${port}/dependency/${packageName}/${packageVersion}/conflicts/${packageName}/${compareWithVer}`,
+    )).data;
+
+    // Has side effect as transident react-reduc dependencies are using different react-is versions.
+    /* Please check 
+    react-is": {"name": "react-is", "version": "^16.7.0",
+    "referredBy": ["hoist-non-react-statics", "react-redux"]},
+    */
+    expect(res.conflics.length).toEqual(1);
+    expect(res.conflics[0]).toEqual(['react-is', '^16.7.0', '^17.0.2']);
   });
 
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,93 @@
+import { VersionMetadata, VersionMetadataParcer } from '../src/types'
+
+describe('/package/:name/:version types', () => {
+  
+  beforeAll(async () => {
+    return;
+    // do nothing
+  });
+
+  afterAll((done) => {
+    done();
+    // do nothing
+  });
+
+  it('valid fixed version', async () => {
+    // arrage
+    const packageVersion = '16.13.0';
+    
+    // act
+    const res: VersionMetadata = VersionMetadataParcer.parse(packageVersion);
+
+    // assert
+    expect(res.rawVersion).toEqual('16.13.0');
+    expect(res.cleanVersion).toEqual('16.13.0');
+    expect(res.isValid).toEqual(true);
+  });
+
+  it('valid alternative versions', async () => {
+    // arrage
+    const packageVersion = '1.13.0 || 2.0.0';
+    
+    // act
+    const res: VersionMetadata = VersionMetadataParcer.parse(packageVersion);
+
+    // assert
+    expect(res.rawVersion).toEqual(packageVersion);
+    expect(res.cleanVersion).toEqual('2.0.0');
+    expect(res.isValid).toEqual(true);
+  });
+
+  it('Valid semantic version with ^', async () => {
+    // arrage
+    const packageVersion = '^1.13.0';
+    
+    // act
+    const res: VersionMetadata = VersionMetadataParcer.parse(packageVersion);
+
+    // assert
+    expect(res.rawVersion).toEqual(packageVersion);
+    expect(res.cleanVersion).toEqual('1.13.0');
+    expect(res.isValid).toEqual(true);
+  });
+
+  it('Valid semantic version with ~', async () => {
+    // arrage
+    const packageVersion = '~1.13.0';
+    
+    // act
+    const res: VersionMetadata = VersionMetadataParcer.parse(packageVersion);
+
+    // assert
+    expect(res.rawVersion).toEqual(packageVersion);
+    expect(res.cleanVersion).toEqual('1.13.0');
+    expect(res.isValid).toEqual(true);
+  });
+
+  it('Valid semantic version with *', async () => {
+    // arrage
+    const packageVersion = '~1.13.*';
+    
+    // act
+    const res: VersionMetadata = VersionMetadataParcer.parse(packageVersion);
+
+    // assert
+    expect(res.rawVersion).toEqual(packageVersion);
+    expect(res.cleanVersion).toEqual('1.13.*');
+    expect(res.isValid).toEqual(true);
+  });
+
+  it('any major *', async () => {
+    // arrage
+    const packageVersion = '*';
+    
+    // act
+    const res: VersionMetadata = VersionMetadataParcer.parse(packageVersion);
+
+    // assert
+    expect(res.rawVersion).toEqual(packageVersion);
+    expect(res.cleanVersion).toEqual(undefined);
+    expect(res.isValid).toEqual(true);
+    expect(res.isAnyMajorVer).toEqual(true);
+  });
+});


### PR DESCRIPTION
There is enhanced endpoint to discover all possible dependency issues between 2 packages and their transient dependencies.
Unit tests has some examples like localhost:3000/dependency/react/18.0.0/conflicts/react/15.0.0.

**Please note that API design is not perfect (not extensible for multiple packages), however browser can be used to check how it works, which will same some time for you to visualized results** 

Scenario instructions imply some flexibility, so I decided take more complex case when developers want to verify all dependencies (including dependencies of dependencies), So basically we are trying to ensure that final package will have only **single** version of each npm package.

**Also, logic is not distributed across multiple files just for reviewers'  convenience. ** 

Algorithm complexity near O(n).